### PR TITLE
fix error if pi password has been deleted using `passwd -d pi`

### DIFF
--- a/etc/profile.d/sshpasswd.sh
+++ b/etc/profile.d/sshpasswd.sh
@@ -7,6 +7,7 @@ check_hash ()
    test -n "${SHADOW}" || return 0
    if echo $SHADOW | grep -q "pi:!" ; then return 0 ; fi
    SALT=$(echo "${SHADOW}" | sed -n 's/pi:\$6\$//;s/\$.*//p')
+   test -n "${SALT}" || return 0
    HASH=$(mkpasswd -msha-512 raspberry "$SALT")
    test -n "${HASH}" || return 0
 


### PR DESCRIPTION
Or else the error `Wrong salt length: 0 bytes when 8 <= n <= 16 expected.` will always be displayed on login.