### PR TITLE
Extend of-compatible-based probing to spi

### DIFF
--- a/lib/udev/rules.d/15-i2c-modprobe.rules
+++ b/lib/udev/rules.d/15-i2c-modprobe.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="i2c", ENV{MODALIAS}=="?*", ENV{OF_NAME}=="?*", ENV{OF_COMPATIBLE_0}=="?*", RUN+="/usr/lib/raspberrypi-sys-mods/i2cprobe"
+SUBSYSTEM=="i2c|spi", ENV{MODALIAS}=="?*", ENV{OF_NAME}=="?*", ENV{OF_COMPATIBLE_0}=="?*", RUN+="/usr/lib/raspberrypi-sys-mods/i2cprobe"


### PR DESCRIPTION
Commit 6f5d2c6009e6 introduced autoloading of drivers for i2c devices based on the OF/DT "compatible" string in addition to the modalias.

Extend this to spi devices to allow autoloading of drivers which declare a `MODULE_DEVICE_TABLE(of, ...)` but no `MODULE_DEVICE_TABLE(spi, ...)`, such as gpio-74x164.c which is used by the Revolution Pi.

It might make sense now to rename `i2cprobe` to `ofprobe` and `15-i2c-modprobe.rules` to `15-of-modprobe.rules`, I can provide an updated commit if you want, or feel free to adjust the name as you please.