### PR TITLE
Add "/boot/setup.sh" hook for headless / batch configuration

### DIFF
--- a/debian/raspberrypi-sys-mods.custom-setup.service
+++ b/debian/raspberrypi-sys-mods.custom-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Execute script if /boot/setup.sh is present
+ConditionPathExistsGlob=/boot/setup.sh
+After=multi-user.target  # Not sure which After= it should use... hrm...
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /boot/setup.sh
+ExecStartPost=/bin/rm -f /boot/setup.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/debian/rules
+++ b/debian/rules
@@ -34,6 +34,7 @@ override_dh_installinit:
 	dh_installinit --name=apply_noobs_os_config --no-restart-on-upgrade --no-start
 	dh_installinit --name=regenerate_ssh_host_keys --no-restart-on-upgrade --no-start
 	dh_installinit --name=wifi-country --no-restart-on-upgrade --no-start
+	dh_installinit --name=custom-setup --no-restart-on-upgrade --no-start
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=rpi-display-backlight
@@ -41,9 +42,11 @@ override_dh_systemd_enable:
 	dh_systemd_enable --name=apply_noobs_os_config --no-enable
 	dh_systemd_enable --name=regenerate_ssh_host_keys --no-enable
 	dh_systemd_enable --name=wifi-country
+	dh_systemd_enable --name=custom-setup
 
 override_dh_systemd_start:
 	dh_systemd_start --name=sshswitch --no-start
 	dh_systemd_start --name=apply_noobs_os_config --no-start
 	dh_systemd_start --name=regenerate_ssh_host_keys --no-start
 	dh_systemd_start --name=wifi-country --no-start
+	dh_systemd_start --name=custom-setup --no-start


### PR DESCRIPTION
After boot, if a file called `/boot/setup.sh` is found, it will be executed and then deleted.

This simple addition would make headless setup far easier, as an arbitrary setup could be configured in the FAT partition immediately on imaging the card rather than having to manually ssh in (through the insecure `pi` user) or building custom Raspbian images that need to be hosted.

As far as I can tell, the `init=` option in `cmdline.txt` does not allow loading of scripts from `/boot` as it is not mounted at that point.