### PR TITLE
check for gettext before executing commands

### DIFF
--- a/etc/profile.d/wifi-country.sh
+++ b/etc/profile.d/wifi-country.sh
@@ -1,7 +1,9 @@
 (
 	export TEXTDOMAIN=wifi-country
 
-	. gettext.sh
+	if [ -x /usr/bin/gettext.sh ]; then
+		. /usr/bin/gettext.sh
+	fi
 
 	if [ ! -f /run/wifi-country-unset ]; then
 		exit 0
@@ -16,7 +18,9 @@
 	fi
 
 	echo
-	/usr/bin/gettext -s "Wi-Fi is disabled because the country is not set."
-	/usr/bin/gettext -s "Use raspi-config to set the country before use."
+	if [ -x /usr/bin/gettext ]; then
+		/usr/bin/gettext -s "Wi-Fi is disabled because the country is not set."
+		/usr/bin/gettext -s "Use raspi-config to set the country before use."
+	fi
 	echo
 )


### PR DESCRIPTION
gettext-base is not defined as dependency for this package, so we have to check for gettext binaries an shell scripts before executing.

https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/23