### PR TITLE
wifi-country: Fix mmc block matching rule

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/wifi-country
+++ b/usr/lib/raspberrypi-sys-mods/wifi-country
@@ -14,7 +14,7 @@ if [ ! -x "/usr/sbin/rfkill" ]; then
 fi
 mkdir -p "/var/lib/systemd/rfkill"
 
-address="$(/bin/grep -m 1 /mmc /proc/iomem | /usr/bin/cut -f1 -d-)"
+address="$(/bin/grep -m 1 mmc@7e300000 /proc/iomem | /usr/bin/cut -f1 -d-)"
 if [ -z "$address" ]; then
 	echo "Could not determine WiFi iomem address"
 	exit 1

--- a/usr/lib/raspberrypi-sys-mods/wifi-country
+++ b/usr/lib/raspberrypi-sys-mods/wifi-country
@@ -14,7 +14,7 @@ if [ ! -x "/usr/sbin/rfkill" ]; then
 fi
 mkdir -p "/var/lib/systemd/rfkill"
 
-address="$(/bin/grep -m 1 mmc@7e300000 /proc/iomem | /usr/bin/cut -f1 -d-)"
+address="$(/bin/grep -m 1 @7e300000 /proc/iomem | /usr/bin/cut -f1 -d-)"
 if [ -z "$address" ]; then
 	echo "Could not determine WiFi iomem address"
 	exit 1


### PR DESCRIPTION
The grep rule for locating the WiFi MMC interface needs fixing on two counts:

1. newer kernels use a different format of /proc/iomem, and
2. the devices are listed in order of increasing address, so the first match is the SDHOST interface at 7e202000. We can't use that interface for SDIO because the clock gating is too aggressive, so we end up with an rfkill block file that is ignored.

Fix both problems by matching on `@7e300000`, making us immune to name changes as well.