### PR TITLE
move rfkill logic into a dedicated script

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/rfkill-wifi
+++ b/usr/lib/raspberrypi-sys-mods/rfkill-wifi
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+state=${1:-1}
+
+if [ ! -x "/usr/sbin/rfkill" ]; then
+	echo "rfkill not installed"
+	exit 1
+fi
+mkdir -p "/var/lib/systemd/rfkill"
+
+address="$(/bin/grep -m 1 @7e300000 /proc/iomem | /usr/bin/cut -f1 -d-)"
+if [ -z "$address" ]; then
+	echo "Could not determine WiFi iomem address"
+	exit 1
+fi
+persist_file="/var/lib/systemd/rfkill/platform-$address.mmc:wlan"
+
+/bin/echo ${state} > "$persist_file"

--- a/usr/lib/raspberrypi-sys-mods/wifi-country
+++ b/usr/lib/raspberrypi-sys-mods/wifi-country
@@ -8,19 +8,6 @@ if /bin/grep -q "^country=[A-Z][A-Z]" /etc/wpa_supplicant/wpa_supplicant.conf; t
 	exit 0
 fi
 
-if [ ! -x "/usr/sbin/rfkill" ]; then
-	echo "rfkill not installed"
-	exit 1
-fi
-mkdir -p "/var/lib/systemd/rfkill"
-
-address="$(/bin/grep -m 1 @7e300000 /proc/iomem | /usr/bin/cut -f1 -d-)"
-if [ -z "$address" ]; then
-	echo "Could not determine WiFi iomem address"
-	exit 1
-fi
-persist_file="/var/lib/systemd/rfkill/platform-$address.mmc:wlan"
-
-/bin/echo 1 > "$persist_file"
+/usr/lib/raspberrypi-sys-mods/rfkill-wifi 1
 /usr/bin/touch /run/wifi-country-unset
 /bin/echo "Wi-Fi is disabled because the country is not set"


### PR DESCRIPTION
this permits the same logic to be used by raspberrypi-net-mods.service
to remove the persistent rfkill block when installing a new
wpa_supplicant.conf.

See the discussion in #27 for details.