### PR TITLE
Detect if openssh-client is installed before regenerating SSH host keys

### DIFF
--- a/debian/raspberrypi-sys-mods.regenerate_ssh_host_keys.service
+++ b/debian/raspberrypi-sys-mods.regenerate_ssh_host_keys.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Regenerate SSH host keys
 Before=ssh.service
+ConditionFileIsExecutable=/usr/bin/ssh-keygen
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Use ConditionFileIsExecutable to detect if ssh-keygen is installed before executing it at boot.

Fixes #29.
