### PR TITLE
Use systemctl to enable/start ssh service

### DIFF
--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -5,7 +5,7 @@ After=regenerate_ssh_host_keys.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "update-rc.d ssh enable && invoke-rc.d ssh start && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
+ExecStart=/bin/sh -c "systemctl enable ssh && systemctl start ssh && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Move away from calling a sysv util to manage a systemd service from within a systemd Unit. Use systemctl instead.