### PR TITLE
i2cprobe: Fix loading of I2C modules without DT aliases

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/i2cprobe
+++ b/usr/lib/raspberrypi-sys-mods/i2cprobe
@@ -1,2 +1,6 @@
 #!/bin/sh
-modprobe ${MODALIAS} || modprobe "of:N${OF_NAME}T<NULL>C${OF_COMPATIBLE_0}"
+ALIASES=/lib/modules/`uname -r`/modules.alias
+if grep -q "alias ${SUBSYSTEM}:${OF_NAME} " $ALIASES; then
+    modprobe "${SUBSYSTEM}:${OF_NAME}" && exit 0
+fi
+modprobe "${MODALIAS}" || modprobe "of:N${OF_NAME}T<NULL>C${OF_COMPATIBLE_0}"


### PR DESCRIPTION
A change in Linux 4.19 has stopped I2C devices instantiated via
Device Tree from generating "i2c:*" aliases for modules, instead
generating "of:*" aliases. This is a problem for modules that
don't declare DT compatible strings. There is also a secondary
issue - the uio_pdrv_genirq driver installs a wildcard alias
that matches any "of:" alias - that makes it harder to tell if a
real driver has registered an alias.

Extend the existing i2cprobe helper to search the aliases file for
a matching "i2c:" alias and probing with it if found, falling back
to the provided alias before finally trying an "of:" alias.

See: https://github.com/raspberrypi/linux/issues/3061

Signed-off-by: Phil Elwell <phil@raspberrypi.org>