### PR TITLE
Enable upstream rtl8192cu for 4.19.x onwards

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+raspberrypi-sys-mods (20190731) UNRELEASED; urgency=medium
+
+  [ macmpi ]
+  * Create blacklist-8192cu.conf
+  * Delete blacklist-rtl8192cu.conf
+
+ -- Serge Schneider <serge@raspberrypi.org>  Tue, 05 Nov 2019 13:30:19 +0000
+
 raspberrypi-sys-mods (20190730) buster; urgency=medium
 
   * Add micro:bit udev rule

--- a/debian/raspberrypi-sys-mods.maintscript
+++ b/debian/raspberrypi-sys-mods.maintscript
@@ -1,2 +1,3 @@
 rm_conffile /etc/profile.d/sshpasswd.sh 20161220
 rm_conffile /etc/profile.d/wifi-country.sh 20190429
+rm_conffile /etc/modprobe.d/blacklist-rtl8192cu.conf 20190730

--- a/etc.armhf/modprobe.d/blacklist-8192cu.conf
+++ b/etc.armhf/modprobe.d/blacklist-8192cu.conf
@@ -1,0 +1,1 @@
+blacklist 8192cu

--- a/etc.armhf/modprobe.d/blacklist-rtl8192cu.conf
+++ b/etc.armhf/modprobe.d/blacklist-rtl8192cu.conf
@@ -1,1 +1,0 @@
-blacklist rtl8192cu


### PR DESCRIPTION
suppress `rtl8192cu` blacklist, and do blacklist downstream [8192cu](url) as per https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/37