### PR TITLE
Update 99-com.rules

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -21,9 +21,9 @@ SUBSYSTEM=="pwm*", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $$ALIASES/uart0 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $$ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -34,9 +34,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if [ -e /dev/ttyAMA0 ]; then \
 		exit 1; \
-	elif cmp -s $$ALIASES/uart0 $ALIASES/serial0; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $$ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -45,9 +45,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $$ALIASES/uart1 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart1 $$ALIASES/serial0; then \
 		echo 0; \
-	elif cmp -s $$ALIASES/uart1 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart1 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -21,9 +21,9 @@ SUBSYSTEM=="pwm*", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart0 $ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -34,9 +34,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if [ -e /dev/ttyAMA0 ]; then \
 		exit 1; \
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+	elif cmp -s $$ALIASES/uart0 $ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -45,9 +45,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart1 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart1 $ALIASES/serial0; then \
 		echo 0; \
-	elif cmp -s $ALIASES/uart1 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart1 $ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \


### PR DESCRIPTION
I'm getting these systemd-udevd messages in syslog:
```
Sep 24 09:32:31 raspberrypi systemd-udevd[107]: /etc/udev/rules.d/99-com.rules:31 Invalid value "/bin/sh -c 'ALIASES=/proc/device-tree/aliases; if cmp -s $ALIASES/uart0 $ALIASES/serial0; then echo 0;elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then echo 1; else exit 1; fi'" for PROGRAM (char 58: invalid substitution type), ignoring, but please fix it.
Sep 24 09:32:31 raspberrypi systemd-udevd[107]: /etc/udev/rules.d/99-com.rules:44 Invalid value "/bin/sh -c 'ALIASES=/proc/device-tree/aliases; if [ -e /dev/ttyAMA0 ]; then exit 1; elif cmp -s $ALIASES/uart0 $ALIASES/serial0; then echo 0;elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then echo 1; else exit 1; fi'" for PROGRAM (char 97: invalid substitution type), ignoring, but please fix it.
Sep 24 09:32:31 raspberrypi systemd-udevd[107]: /etc/udev/rules.d/99-com.rules:55 Invalid value "/bin/sh -c 'ALIASES=/proc/device-tree/aliases; if cmp -s $ALIASES/uart1 $ALIASES/serial0; then echo 0; elif cmp -s $ALIASES/uart1 $ALIASES/serial1; then echo 1; else exit 1; fi '" for PROGRAM (char 58: invalid substitution type), ignoring, but please fix it.
```
Changing `$ALIASES` to `$$ALIASES` fixes the "invalid substitution type" issue and allows the rules to work as intended.

I'm using udev 246.4-1+rpi1 from the testing distribution. Not sure if that's relevant.