### PR TITLE
run_once: execute /boot/run_once when booting

### DIFF
--- a/debian/raspberrypi-sys-mods.run_once.service
+++ b/debian/raspberrypi-sys-mods.run_once.service
@@ -1,0 +1,18 @@
+# This unit is heavily inspired by Ned McClain's ideas found in https://github.com/nmcclain/raspberian-firstboot
+[Unit]
+Description=run_once initialization
+After=network.target
+Before=rc-local.service
+
+ConditionFileNotEmpty=/boot/run_once
+ConditionFileIsExecutable=/boot/run_once
+ConditionPathIsReadWrite=/boot
+
+[Service]
+ExecStart=/boot/run_once
+ExecStartPost=/bin/mv /boot/run_once /boot/run_once.${INVOCATION_ID}
+Type=oneshot
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,7 @@ include /usr/share/dpkg/default.mk
 override_dh_installinit:
 	dh_installinit --name=rpi-display-backlight --no-stop-on-upgrade --no-start
 	dh_installinit --name=sshswitch
+	dh_installinit --name=run_once
 	dh_installinit --name=apply_noobs_os_config --no-stop-on-upgrade --no-start
 	dh_installinit --name=regenerate_ssh_host_keys --no-stop-on-upgrade --no-start
 	dh_installinit --name=wifi-country --no-stop-on-upgrade --no-start
@@ -38,12 +39,14 @@ override_dh_installinit:
 override_dh_systemd_enable:
 	dh_systemd_enable --name=rpi-display-backlight
 	dh_systemd_enable --name=sshswitch
+	dh_systemd_enable --name=run_once
 	dh_systemd_enable --name=apply_noobs_os_config --no-enable
 	dh_systemd_enable --name=regenerate_ssh_host_keys --no-enable
 	dh_systemd_enable --name=wifi-country
 
 override_dh_systemd_start:
 	dh_systemd_start --name=sshswitch --no-start
+	dh_systemd_start --name=run_once --no-start
 	dh_systemd_start --name=apply_noobs_os_config --no-start
 	dh_systemd_start --name=regenerate_ssh_host_keys --no-start
 	dh_systemd_start --name=wifi-country --no-start


### PR DESCRIPTION
Based on Ned McClain's ideas found in https://github.com/nmcclain/raspberian-firstboot this pull request will enable newly flashed Raspberry Pi's to be easily provisioned by simply adding an executable to the /boot partition right after flashing sd cards.

Let me know what you think :)