### PR TITLE
Make Microsoft Repo optional

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/RPi-Distro/raspberrypi-sys-mods
 Package: raspberrypi-sys-mods
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libcap2-bin, systemd (>= 230),
- gettext-base
+ gettext-base, debconf (>= 0.5) | debconf-2.0
 Recommends: rfkill, rpi-eeprom
 Description: System tweaks for the Raspberry Pi
  Various modifications to improve the performance or user experience.

--- a/debian/raspberrypi-sys-mods.postinst
+++ b/debian/raspberrypi-sys-mods.postinst
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
 check_audio () {
   # audio dtparam mentioned in config.txt (enabled, disabled or commented out)
   AM_PAT="^[[:space:]]*#?[[:space:]]*(device_tree_param|dtparam)[[:space:]]*=[[:space:]]*([^,]*,)*audio[[:space:]]*=.*$"
@@ -29,18 +32,22 @@ check_audio () {
 }
 
 add_ms_repo () {
-	eval "$(apt-config shell APT_SOURCE_PARTS Dir::Etc::sourceparts/d)"
-	CODE_SOURCE_PART="${APT_SOURCE_PARTS}vscode.list"
-  if [ -f "$CODE_SOURCE_PART" ]; then
-    echo "Already exists. Skipped."
-    return 0
-  fi
-	eval "$(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)"
-	CODE_TRUSTED_PART="${APT_TRUSTED_PARTS}microsoft.gpg"
+    db_input high raspberrypi-sys-mods/setup_ms_repo || false
+    db_go
+    db_get raspberrypi-sys-mods/setup_ms_repo
+    if [ "$RET" = "true" ]; then
+		eval "$(apt-config shell APT_SOURCE_PARTS Dir::Etc::sourceparts/d)"
+		CODE_SOURCE_PART="${APT_SOURCE_PARTS}vscode.list"
+	  if [ -f "$CODE_SOURCE_PART" ]; then
+	    echo "Already exists. Skipped."
+	    return 0
+	  fi
+		eval "$(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)"
+		CODE_TRUSTED_PART="${APT_TRUSTED_PARTS}microsoft.gpg"
 
-	# Sourced from https://packages.microsoft.com/keys/microsoft.asc
-	if [ ! -f "$CODE_TRUSTED_PART" ]; then
-		echo "-----BEGIN PGP PUBLIC KEY BLOCK-----
+		# Sourced from https://packages.microsoft.com/keys/microsoft.asc
+		if [ ! -f "$CODE_TRUSTED_PART" ]; then
+			echo "-----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.7 (GNU/Linux)
 
 mQENBFYxWIwBCADAKoZhZlJxGNGWzqV+1OG1xiQeoowKhssGAKvd+buXCGISZJwT
@@ -59,23 +66,24 @@ XdNgj4Jd2/g6T9InmWT0hASljur+dJnzNiNCkbn9KbX7J/qK1IbR8y560yRmFsU+
 NdCFTW7wY0Fb1fWJ+/KTsC4=
 =J6gs
 -----END PGP PUBLIC KEY BLOCK-----
-" | gpg --dearmor > microsoft.gpg
-		mv microsoft.gpg "$CODE_TRUSTED_PART"
-	fi
+	" | gpg --dearmor > microsoft.gpg
+			mv microsoft.gpg "$CODE_TRUSTED_PART"
+		fi
 
-	# Install repository source list
-	WRITE_SOURCE=0
-	if [ ! -f "$CODE_SOURCE_PART" ]; then
-		# Write source list if it does not exist
-		WRITE_SOURCE=1
-	elif grep -q "# disabled on upgrade to" /etc/apt/sources.list.d/vscode.list; then
-		# Write source list if it was disabled by OS upgrade
-		WRITE_SOURCE=1
-	fi
-	if [ "$WRITE_SOURCE" -eq "1" ]; then
-		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+		# Install repository source list
+		WRITE_SOURCE=0
+		if [ ! -f "$CODE_SOURCE_PART" ]; then
+			# Write source list if it does not exist
+			WRITE_SOURCE=1
+		elif grep -q "# disabled on upgrade to" /etc/apt/sources.list.d/vscode.list; then
+			# Write source list if it was disabled by OS upgrade
+			WRITE_SOURCE=1
+		fi
+		if [ "$WRITE_SOURCE" -eq "1" ]; then
+			echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
 deb [arch=amd64,arm64,armhf] http://packages.microsoft.com/repos/code stable main" > "$CODE_SOURCE_PART"
+		fi
 	fi
 }
 

--- a/debian/templates
+++ b/debian/templates
@@ -1,0 +1,4 @@
+Template: raspberrypi-sys-mods/setup_ms_repo
+Type: boolean
+Description: Setup Microsoft Repository?
+ This will setup the Microsoft Repository so VS Code can be installed more easily.


### PR DESCRIPTION
Hi,
this PR addresses #42, #43, #44, #49 and #50 (from what I can tell) and makes the configuration of the Microsoft Repo optional (opt-in as opposed to #51).

This also requires a new dependency: `debconf` 

The key `raspberrypi-sys-mods/setup_ms_repo` is used to keep track of the users choice.