### PR TITLE
sshswitch: in case systemctl(1) fails, don't remove any /boot/ssh* files

### DIFF
--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -5,7 +5,7 @@ After=regenerate_ssh_host_keys.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "systemctl enable --now ssh && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
+ExecStart=/bin/sh -c "systemctl enable --now ssh && rm -f /boot/ssh /boot/ssh.txt"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There is a possibility, when a user creates `/boot/ssh.txt` and 
`systemctl enable --now ssh` fails, file `/boot/ssh.txt` will be
removed, when it shouldn't. Treat both file markers the same
and use one `rm(1)` command to remove them.
