### PR TITLE
Grant ICMP permission to all users

### DIFF
--- a/debian/raspberrypi-sys-mods.postinst
+++ b/debian/raspberrypi-sys-mods.postinst
@@ -43,8 +43,6 @@ case "${1}" in
     fi
     if dpkg --compare-versions "${2}" lt "20160321+1"; then
       echo "Fixing file capabilities..."
-      setcap cap_net_raw+ep /bin/ping6 || true
-      setcap cap_net_raw+ep /bin/ping || true
       setcap cap_dac_override,cap_sys_ptrace+ep /usr/bin/systemd-detect-virt || true
     fi
     if dpkg --compare-versions "${2}" lt "20160321"; then

--- a/etc.arm/sysctl.d/98-rpi.conf
+++ b/etc.arm/sysctl.d/98-rpi.conf
@@ -1,2 +1,3 @@
 kernel.printk = 3 4 1 3
 vm.min_free_kbytes = 16384
+net.ipv4.ping_group_range = 0 2147483647


### PR DESCRIPTION
This is a more specific and hence more secure solution to allow "ping" usage to all users without sudo, compared to granting "cap_net_raw" via the ping executable itself and it hence replaces the related patch.

Other than the name indicates, this implies ICMPv4 as well as ICMPv6, and is implies all usage of the ICMP protocol, instead of being bound to the single binary, which can be removed and reinstalled to have the capability lost.

Many distros and upstream systemd apply this by default. Further details and related discussions across other projects have been collected here: https://github.com/MichaIng/DietPi/issues/1012