### PR TITLE
If ssh keys are found in /boot/ssh, add these to authorized_keys & disable default pw

### DIFF
--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -5,7 +5,8 @@ After=regenerate_ssh_host_keys.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "systemctl enable --now ssh && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
+# Be aware that /bin/sh does not suppor the ssh{,.txt} syntax
+ExecStart=/bin/sh -c "if grep -q ^ssh- /boot/ssh /boot/ssh.txt; then mkdir /home/pi/.ssh; chmod u=rwx,go= /home/pi/.ssh ; grep -h ^ssh- /boot/ssh /boot/ssh.txt > /home/pi/.ssh/authorized_keys; chown -R pi.pi /home/pi/.ssh; passwd -l pi ; fi ; systemctl enable --now ssh && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -5,7 +5,7 @@ After=regenerate_ssh_host_keys.service
 
 [Service]
 Type=oneshot
-# Be aware that /bin/sh does not suppor the ssh{,.txt} syntax
+# Be aware that /bin/sh does not support the ssh{,.txt} syntax
 ExecStart=/bin/sh -c "if grep -q ^ssh- /boot/ssh /boot/ssh.txt; then mkdir /home/pi/.ssh; chmod u=rwx,go= /home/pi/.ssh ; grep -h ^ssh- /boot/ssh /boot/ssh.txt > /home/pi/.ssh/authorized_keys; chown -R pi.pi /home/pi/.ssh; passwd -l pi ; fi ; systemctl enable --now ssh && rm -f /boot/ssh /boot/ssh.txt"
 
 [Install]

--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -6,7 +6,7 @@ After=regenerate_ssh_host_keys.service
 [Service]
 Type=oneshot
 # Be aware that /bin/sh does not suppor the ssh{,.txt} syntax
-ExecStart=/bin/sh -c "if grep -q ^ssh- /boot/ssh /boot/ssh.txt; then mkdir /home/pi/.ssh; chmod u=rwx,go= /home/pi/.ssh ; grep -h ^ssh- /boot/ssh /boot/ssh.txt > /home/pi/.ssh/authorized_keys; chown -R pi.pi /home/pi/.ssh; passwd -l pi ; fi ; systemctl enable --now ssh && rm -f /boot/ssh ; rm -f /boot/ssh.txt"
+ExecStart=/bin/sh -c "if grep -q ^ssh- /boot/ssh /boot/ssh.txt; then mkdir /home/pi/.ssh; chmod u=rwx,go= /home/pi/.ssh ; grep -h ^ssh- /boot/ssh /boot/ssh.txt > /home/pi/.ssh/authorized_keys; chown -R pi.pi /home/pi/.ssh; passwd -l pi ; fi ; systemctl enable --now ssh && rm -f /boot/ssh /boot/ssh.txt"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I like installing Raspberry Pi OS using 'dd'. I then `touch /boot/ssh` to enable ssh, and then I have to log in using a default password, provision my own SSH public key for access, and disable the default password. This is clunky and error prone.

With this PR, touching /boot/ssh (or /boot/ssh.txt) will still enable SSH access as usual. 

However, if you put one or more valid SSH public keys in that file, they will get provisioned to ~pi/.ssh/authorized keys, and the default password will be disabled. This closes a security gap.

I have tested this PR many times on fresh installs, and I have also verified that the old behaviour is unchanged. Some discussion can be found on https://twitter.com/PowerDNS_Bert/status/1426247244412604424

For ease of merging, I have incorporated #55 in this PR, since it is 1) useful and 2) would generate a conflict with this PR. Thanks to @Habbie for this & other great suggestions. 