### PR TITLE
Simplify GPIO/PWM udev rules

### DIFF
--- a/etc.arm/udev/rules.d/99-com.rules
+++ b/etc.arm/udev/rules.d/99-com.rules
@@ -8,16 +8,11 @@ KERNEL=="vcsm-cma", GROUP="video", MODE="0660"
 SUBSYSTEM=="dma_heap", GROUP="video", MODE="0660"
 
 SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"
-SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c '\
-	chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio;\
-	chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio;\
-	chown -R root:gpio /sys$devpath && chmod -R 770 /sys$devpath\
-'"
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys/class/gpio && chmod -R g=u /sys/class/gpio'"
+SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p && chmod -R g=u /sys%p'"
 
-SUBSYSTEM=="pwm*", PROGRAM="/bin/sh -c '\
-	chown -R root:gpio /sys/class/pwm && chmod -R 770 /sys/class/pwm;\
-	chown -R root:gpio /sys/devices/platform/soc/*.pwm/pwm/pwmchip* && chmod -R 770 /sys/devices/platform/soc/*.pwm/pwm/pwmchip*\
-'"
+# PWM export results in a "change" action on the pwmchip device (not "add" of a new device), so match actions other than "remove".
+SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p && chmod -R g=u /sys%p'"
 
 KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \


### PR DESCRIPTION
- `chown -R root:gpio ...` is changed to `chgrp -R gpio` for brevity.
- `chmod -R 770 ...` is changed to `chmod -R g=u ...` to avoid adding permissions that don't make sense (+x on files, +w on readonly properties).
- `/sys$devpath` replaced with the equivalent `/sys%p`
- /sys/class/gpio (which is only needed for /sys/class/gpio/{export,unexport}) is touched as infrequently as possible (only when a new gpiochip device is added)
- Hardcoded path /sys/devices/platform/soc/*.pwm/pwm/pwmchip* replaced with /sys%p.
- Hardcoded path /sys/devices/virtual/gpio also removed (looks like this hasn't been a thing since ~2015, and I suspect /sys%p would be sufficient).