### PR TITLE
Create vscode repo dummy/block only when required

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raspberrypi-sys-mods (20220106) bullseye; urgency=medium
+
+  [ MichaIng ]
+  * Remove vscode repo dummy/block
+
+ -- Serge Schneider <serge@raspberrypi.com>  Thu, 06 Jan 2022 09:10:17 +0000
+
 raspberrypi-sys-mods (20211005+bullseye) bullseye; urgency=medium
 
   [ tc287 ]

--- a/debian/raspberrypi-sys-mods.postinst
+++ b/debian/raspberrypi-sys-mods.postinst
@@ -1,12 +1,12 @@
 #!/bin/sh -e
 
-block_ms_repo () {
+remove_ms_stubs () {
   eval "$(apt-config shell APT_SOURCE_PARTS Dir::Etc::sourceparts/d)"
   CODE_SOURCE_PART="${APT_SOURCE_PARTS}vscode.list"
   eval "$(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)"
   CODE_TRUSTED_PART="${APT_TRUSTED_PARTS}microsoft.gpg"
-  [ ! -f "$CODE_SOURCE_PART" ] || echo "### Disabled by raspberrypi-sys-mods ###" > "$CODE_SOURCE_PART" || :
-  [ ! -f "$CODE_TRUSTED_PART" ] || > "$CODE_TRUSTED_PART" || :
+  grep -qsv '^[[:space:]]*#' "$CODE_SOURCE_PART" || rm -f "$CODE_SOURCE_PART"
+  grep -qsv '^[[:space:]]*#' "$CODE_TRUSTED_PART" || rm -f "$CODE_TRUSTED_PART"
 }
 
 case "${1}" in
@@ -21,9 +21,9 @@ case "${1}" in
         ln -sf /dev/null /etc/systemd/network/73-usb-net-by-mac.link
       fi
     fi
-    if dpkg --compare-versions "${2}" lt-nl "20210310"; then
-      echo "Blocking vscode repo..."
-      block_ms_repo
+    if dpkg --compare-versions "${2}" lt-nl "20220106"; then
+      echo "Removing vscode repo stubs..."
+      remove_ms_stubs
     fi
     ;;
 

--- a/debian/raspberrypi-sys-mods.postinst
+++ b/debian/raspberrypi-sys-mods.postinst
@@ -5,7 +5,8 @@ block_ms_repo () {
   CODE_SOURCE_PART="${APT_SOURCE_PARTS}vscode.list"
   eval "$(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)"
   CODE_TRUSTED_PART="${APT_TRUSTED_PARTS}microsoft.gpg"
-  echo "### Disabled by raspberrypi-sys-mods ###" > "$CODE_TRUSTED_PART" > "$CODE_SOURCE_PART" ||:
+  [ ! -f "$CODE_SOURCE_PART" ] || echo "### Disabled by raspberrypi-sys-mods ###" > "$CODE_SOURCE_PART" || :
+  [ ! -f "$CODE_TRUSTED_PART" ] || > "$CODE_TRUSTED_PART" || :
 }
 
 case "${1}" in
@@ -20,7 +21,7 @@ case "${1}" in
         ln -sf /dev/null /etc/systemd/network/73-usb-net-by-mac.link
       fi
     fi
-    if dpkg --compare-versions "${2}" lt "20210310"; then
+    if dpkg --compare-versions "${2}" lt-nl "20210310"; then
       echo "Blocking vscode repo..."
       block_ms_repo
     fi


### PR DESCRIPTION
Currently on fresh package installs/images the two vscode repo dummy files are created, which is somehow confusing and not required when the repository is not actually installed or has been manually removed.

On a fresh package install, the step is now skipped and each dummy file is created only to overwrite the existing file.