### PR TITLE
fix: fixes hanging firstboot with kernel 6.1y

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raspberrypi-sys-mods (20230329) bullseye; urgency=medium
+
+  [ Stephan Wendel ]
+  * refactor: refactor generate DISKID
+
+ -- Serge Schneider <serge@raspberrypi.com>  Wed, 29 Mar 2023 07:36:20 +0100
+
 raspberrypi-sys-mods (20221019) bullseye; urgency=medium
 
   [ hungryhorace ]

--- a/usr/lib/raspberrypi-sys-mods/firstboot
+++ b/usr/lib/raspberrypi-sys-mods/firstboot
@@ -63,7 +63,7 @@ get_variables () {
 fix_partuuid() {
   mount -o remount,rw "$ROOT_PART_DEV"
   mount -o remount,rw "$BOOT_PART_DEV"
-  DISKID="$(tr -dc 'a-f0-9' < /dev/hwrng | dd bs=1 count=8 2>/dev/null)"
+  DISKID="$(dd if=/dev/hwrng bs=4 count=1 status=none | od -An -tx4 | cut -c2-9)"
   fdisk "$ROOT_DEV" > /dev/null <<EOF
 x
 i
@@ -223,6 +223,7 @@ main () {
     apply_custom "/boot/custom.toml"
   fi
 
+  whiptail --infobox "Fix PARTUUID..." 20 60
   fix_partuuid
 
   return 0


### PR DESCRIPTION
This fixes issue with preinstalled kernel 6.1y,
which leads to an hanging first boot in function `fix_partuuid` on Raspberry Pi Zero 2 W and Pi 3 series.

Instead of waiting for `/dev/hwrng` to produce enough symbols, force it to write to `/dev/urandom` and read from there.

This should fix https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/70