### PR TITLE
Support all characters in WiFi SSID and key from rpi-imager

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/imager_custom
+++ b/usr/lib/raspberrypi-sys-mods/imager_custom
@@ -126,6 +126,10 @@ set_wlan () (
     set_wlan_country "$COUNTRY"
   fi
 
+  # Replace ' with '\'' in SSID and PASS to support single-quote characters
+  SSID=$(printf '%s' "$SSID" | sed "s/'/'\\\\''/g")
+  PASS=$(printf '%s' "$PASS" | sed "s/'/'\\\\''/g")
+
   mkdir -p "$(dirname "$SCRIPT")"
   # shellcheck disable=SC2094
   cat <<- EOF > "$SCRIPT"
@@ -133,7 +137,7 @@ set_wlan () (
 	COUNTER=0
 	while [ "\$COUNTER" -lt 10 ]; do
 	  COUNTER=\$((COUNTER + 1))
-	  if raspi-config nonint do_wifi_ssid_passphrase  "$SSID" "$PASS" "$HIDDEN" "$PLAIN"; then
+	  if raspi-config nonint do_wifi_ssid_passphrase  '$SSID' '$PASS' '$HIDDEN' '$PLAIN'; then
 	    break
 	  fi
 	  sleep 5
@@ -143,7 +147,7 @@ set_wlan () (
 	rm -f "\$0"
 	rm -f /etc/systemd/system/set-wlan.timer
 	rm -f /etc/systemd/system/set-wlan.service
-	rmdir --ignore-fail-on-non-empty "$(dirname "$SCRIPT")"
+	rmdir --ignore-fail-on-non-empty '$(dirname "$SCRIPT")'
 	EOF
   chmod 700 "$SCRIPT"
 


### PR DESCRIPTION
Fixes: https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/72

In here documents, without the identifier (EOL) being single-quoted, variables and command substitutions are expanded, like in double-quoted strings. To prevent an unintended second expansion of the content of these variables when the document itself is loaded, the calls should be single-quoted. To allow using the single-quote character itself as content of these variables, it needs to be escaped so that `'` becomes `'\''`, i.e. the single-quoted string is ended, then an escaped single-quote character is printed, finally the second part of the single-quoted string is opened again.