### PR TITLE
Improve serial symlink (/dev/serial<n>) creation

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -14,39 +14,24 @@ SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p && c
 # PWM export results in a "change" action on the pwmchip device (not "add" of a new device), so match actions other than "remove".
 SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p && chmod -R g=u /sys%p'"
 
-KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
-	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
-		echo 0;\
-	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
-		echo 1; \
-	else \
-		exit 1; \
-	fi\
-'", SYMLINK+="serial%c"
-
-KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
-	ALIASES=/proc/device-tree/aliases; \
-	if [ -e /dev/ttyAMA0 ]; then \
-		exit 1; \
-	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
-		echo 0;\
-	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
-		echo 1; \
-	else \
-		exit 1; \
-	fi\
-'", SYMLINK+="serial%c"
-
-KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
-	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $$ALIASES/uart1 $$ALIASES/serial0; then \
-		echo 0; \
-	elif cmp -s $$ALIASES/uart1 $$ALIASES/serial1; then \
-		echo 1; \
-	else \
-		exit 1; \
-	fi \
+KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
+        ALIASES=/proc/device-tree/aliases; \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device/of_node | sed 's/base/:/' | cut -d: -f2); \
+        if [ -e $$ALIASES/bluetooth ] && [ $$TTYNODE/bluetooth = $$(strings $$ALIASES/bluetooth) ]; then \
+            echo 1; \
+        elif [ -e $$ALIASES/console ]; then \
+            if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
+                echo 0;\
+            else \
+                exit 1; \
+            fi \
+        elif [ $$TTYNODE = $$(strings $$ALIASES/serial0) ]; then \
+            echo 0; \
+        elif [ $$TTYNODE = $$(strings $$ALIASES/serial1) ]; then \
+            echo 1; \
+        else \
+            exit 1; \
+        fi \
 '", SYMLINK+="serial%c"
 
 ACTION=="add", SUBSYSTEM=="vtconsole", KERNEL=="vtcon1", RUN+="/bin/sh -c '\


### PR DESCRIPTION
The kernel change that sets UART indexes based on Device Tree aliases gives predictable UART /dev/tty* names but has the potential to break our downstream use for determining which UART is the console ("serial0") and which is for Blueooth ("serial1"). Instead we use the "console" and "bluetooth" aliases respectively.

As a bonus, the improved console matching (based on /sys/class/tty entries) also allows us to handle all UARTs with one rule.