### PR TITLE
Don't try to improve Kernel randomness

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys
+++ b/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys
@@ -1,8 +1,5 @@
 #!/bin/sh -e
 
-if [ -c /dev/hwrng ]; then
-  dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 status=none
-fi
 rm -f /etc/ssh/ssh_host_*_key*
 ssh-keygen -A > /dev/null
 systemctl -q disable regenerate_ssh_host_keys


### PR DESCRIPTION
According Kernel developer Jason A. Donenfeld it's not the job of userspace to care of randomness:

"That script has *always* been wrong. Writing to /dev/urandom like that has *never* ensured that those bytes are taken into account immediately after. It's just not how that interface works. So any assumptions based on that are bogus, and that line effectively does nothing.

Fortunately, however, the kernel itself incorporates hwrng output into the rng pool, so you don't need to think about doing it yourself.

So go ahead and remove that line from your script."

Link: https://lore.kernel.org/linux-crypto/20e3c73c-7736-b010-516a-6618c88d8dad@gmx.net/T/#mfd7cca35fe18d6039fbcb2201317a38456cb5b67