### PR TITLE
Relax the udev gpiomem name matching

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -1,7 +1,7 @@
 SUBSYSTEM=="input", GROUP="input", MODE="0660"
 SUBSYSTEM=="i2c-dev", GROUP="i2c", MODE="0660"
 SUBSYSTEM=="spidev", GROUP="spi", MODE="0660"
-SUBSYSTEM=="bcm2835-gpiomem", GROUP="gpio", MODE="0660"
+SUBSYSTEM=="*gpiomem*", GROUP="gpio", MODE="0660"
 SUBSYSTEM=="rpivid-*", GROUP="video", MODE="0660"
 
 KERNEL=="vcsm-cma", GROUP="video", MODE="0660"


### PR DESCRIPTION
Add some wildcards to the udev gpiomem name matching for increased flexibility.