### PR TITLE
Remove fix_wpa call because it was removed

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/firstboot
+++ b/usr/lib/raspberrypi-sys-mods/firstboot
@@ -80,9 +80,6 @@ apply_custom () {
 main () {
   get_variables
 
-  # Switch to dhcpcd here if Imager < v1.7.3 was used to generate firstrun.sh
-  fix_wpa > /dev/null 2>&1
-
   whiptail --infobox "Generating SSH keys..." 20 60
   regenerate_ssh_host_keys
 


### PR DESCRIPTION
Hi, I think you forgot to remove these lines, since dhcpcd is now unsupported after this commit 45b2f1c09e4726e1bf8d7b9c7c8f27fbab4edb68.

