### PR TITLE
Fix mount name

### DIFF
--- a/debian/raspberrypi-sys-mods.sshswitch.service
+++ b/debian/raspberrypi-sys-mods.sshswitch.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Turn on SSH if /boot/ssh or /boot/firmware/ssh is present
-After=regenerate_ssh_host_keys.service boot.mount
+After=regenerate_ssh_host_keys.service boot-firmware.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
boot.mount doesn't exist on a Bookworm install and causes sshservice to run before /boot/firmware is mounted on a netboot install. The correct name is boot-firmware.mount