### PR TITLE
Update get_fw_loc

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/get_fw_loc
+++ b/usr/lib/raspberrypi-sys-mods/get_fw_loc
@@ -5,7 +5,7 @@ if [ -r /etc/default/raspberrypi-sys-mods ]; then
 fi
 
 if [ -z "$FWLOC" ]; then
-  if dpkg --print-architecture | grep -q '^arm'; then
+  if dpkg --print-architecture | grep -q '^arm' && [[ $(findmnt -n /|awk {'print $3'}) != nfs ]]; then
     for FWLOC in /boot /boot/firmware NOT_FOUND; do
       if ( findmnt --fstab "$FWLOC" || findmnt "$FWLOC" ) > /dev/null; then
         break


### PR DESCRIPTION
Modify the logic so that if root is nfs mounted FWLOC defaults to /boot

Without this a nfs mounted headless arm system can't enable ssh, as it passes the arm condition, but fails the having /boot or /boot/firmware defined in fstab condirion