### PR TITLE
Add udev rule for I2C aliases

### DIFF
--- a/lib/udev/rules.d/60-i2c-aliases.rules
+++ b/lib/udev/rules.d/60-i2c-aliases.rules
@@ -1,0 +1,8 @@
+SUBSYSTEM=="i2c-dev",KERNEL=="i2c-[0-9]*", GROUP="i2c", MODE="0660", PROGRAM="/bin/sh -c '\
+        DTNODE=/sys/class/i2c-dev/%k/device/of_node; \
+        if [ -e $$DTNODE/symlink ]; then \
+            cat $$DTNODE/symlink; \
+        else \
+            exit 1; \
+        fi \
+'", SYMLINK+="%c"


### PR DESCRIPTION
Add the ability to create symlink alises to I2C controller devices based on information present in Device Tree. This is to regularise the cameras and display I2C bus numbers on CM5 (i2c-10, i2c-11) while still supporting the hardware bus numbers (i2c-4, i2c-6).