### PR TITLE
serial0: Workaround for removal of of_node in 6.12 kernel

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -13,7 +13,7 @@ SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p &&
 
 KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
-        TTYNODE=$$(readlink /sys/class/tty/%k/device/of_node | sed 's/base/:/' | cut -d: -f2); \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' ); \
         if [ -e $$ALIASES/console ]; then \
             if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
                 echo 0; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -13,7 +13,7 @@ SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p &&
 
 KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
-        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' ); \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' | sed 's/@3f/@fe' ); \
         if [ -e $$ALIASES/console ]; then \
             if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
                 echo 0; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -19,6 +19,10 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
                 echo 0; \
             elif [ -e $$ALIASES/bluetooth ] && [ $$TTYNODE/bluetooth = $$(strings $$ALIASES/bluetooth) ]; then \
                 echo 1; \
+            elif [ $$TTYNODE = $$(strings $$ALIASES/console | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+               echo 0; \
+            elif [ $$TTYNODE = $$(strings $$ALIASES/console | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
+               echo 0; \
             else \
                 exit 1; \
             fi \
@@ -26,6 +30,10 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
             echo 0; \
         elif [ $$TTYNODE = $$(strings $$ALIASES/serial1) ]; then \
             echo 1; \
+        elif [ $$TTYNODE = $$(strings $$ALIASES/uart0 | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
+            echo 0; \
+        elif [ $$TTYNODE = $$(strings $$ALIASES/uart10 | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+            echo 0; \
         else \
             exit 1; \
         fi \


### PR DESCRIPTION
The 6.12 kernel no longer provides the of_node here /sys/class/tty/ttyS0/device/of_node

Instead, use the peripheral address in the device name and attempt to match that to device-tree.