### PR TITLE
fixup! serial0: Workaround for removal of of_node in 6.12 kernel (#95)

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -13,7 +13,7 @@ SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p &&
 
 KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
-        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' | sed 's/@3f/@fe' ); \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' | sed 's/@3f/@fe/' ); \
         if [ -e $$ALIASES/console ]; then \
             if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
                 echo 0; \


### PR DESCRIPTION
See: https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/96