### PR TITLE
More serial fixes

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -13,14 +13,14 @@ SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p &&
 
 KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
-        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@\\\(20\\\|3f\\\|fe\\\)/@7e/' ); \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed -e 's/.*\\//\\/soc\\/serial@/' -e 's/\\..*//' -e 's/@\\\(20\\\|3f\\\|fe\\\)/@7e/' ); \
         if [ -e $$ALIASES/console ]; then \
             CONSOLENODE=$$(strings $$ALIASES/console); \
             if [ $$TTYNODE = $$CONSOLENODE ]; then \
                 echo 0; \
             elif [ -e $$ALIASES/bluetooth ] && [ $$TTYNODE/bluetooth = $$(strings $$ALIASES/bluetooth) ]; then \
                 echo 1; \
-            elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+            elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed -e 's/.*\\//\\/soc\\//' -e 's/serial@/serial@10/' ) ]; then \
                echo 0; \
             elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
                echo 0; \
@@ -33,7 +33,7 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
             echo 1; \
         elif [ -e $$ALIASES/uart0 ] && [ $$TTYNODE = $$(strings $$ALIASES/uart0 | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
             echo 0; \
-        elif [ -e $$ALIASES/uart10 ] && [ $$TTYNODE = $$(strings $$ALIASES/uart10 | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+        elif [ -e $$ALIASES/uart10 ] && [ $$TTYNODE = $$(strings $$ALIASES/uart10 | sed -e 's/.*\\//\\/soc\\//' -e 's/serial@/serial@10/' ) ]; then \
             echo 0; \
         else \
             exit 1; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -15,13 +15,14 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
         TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@\\\(20\\\|3f\\\|fe\\\)/@7e/' ); \
         if [ -e $$ALIASES/console ]; then \
-            if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
+            CONSOLENODE=$$(strings $$ALIASES/console); \
+            if [ $$TTYNODE = $$CONSOLENODE ]; then \
                 echo 0; \
             elif [ -e $$ALIASES/bluetooth ] && [ $$TTYNODE/bluetooth = $$(strings $$ALIASES/bluetooth) ]; then \
                 echo 1; \
-            elif [ $$TTYNODE = $$(strings $$ALIASES/console | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+            elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
                echo 0; \
-            elif [ $$TTYNODE = $$(strings $$ALIASES/console | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
+            elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
                echo 0; \
             else \
                 exit 1; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -13,7 +13,7 @@ SUBSYSTEM=="pwm", ACTION!="remove", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p &&
 
 KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
         ALIASES=/proc/device-tree/aliases; \
-        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@f/@7/' | sed 's/@3f/@fe/' ); \
+        TTYNODE=$$(readlink /sys/class/tty/%k/device | sed 's/.*\\//\\/soc\\/serial@/' | sed 's/\\..*//' | sed 's/@\\\(20\\\|3f\\\|fe\\\)/@7e/' ); \
         if [ -e $$ALIASES/console ]; then \
             if [ $$TTYNODE = $$(strings $$ALIASES/console) ]; then \
                 echo 0; \

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -21,9 +21,9 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
             elif [ -e $$ALIASES/bluetooth ] && [ $$TTYNODE/bluetooth = $$(strings $$ALIASES/bluetooth) ]; then \
                 echo 1; \
             elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed -e 's/.*\\//\\/soc\\//' -e 's/serial@/serial@10/' ) ]; then \
-               echo 0; \
+                echo 0; \
             elif [ $$TTYNODE = $$(echo $$CONSOLENODE | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
-               echo 0; \
+                echo 0; \
             else \
                 exit 1; \
             fi \
@@ -41,7 +41,7 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
 '", SYMLINK+="serial%c"
 
 ACTION=="add", SUBSYSTEM=="vtconsole", KERNEL=="vtcon1", RUN+="/bin/sh -c '\
-	if echo RPi-Sense FB | cmp -s /sys/class/graphics/fb0/name; then \
-		echo 0 > /sys$devpath/bind; \
-	fi; \
+        if echo RPi-Sense FB | cmp -s /sys/class/graphics/fb0/name; then \
+            echo 0 > /sys$devpath/bind; \
+        fi; \
 '"

--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -26,13 +26,13 @@ KERNEL=="ttyAMA[0-9]*|ttyS[0-9]*", PROGRAM="/bin/sh -c '\
             else \
                 exit 1; \
             fi \
-        elif [ $$TTYNODE = $$(strings $$ALIASES/serial0) ]; then \
+        elif [ -e $$ALIASES/serial0 ] && [ $$TTYNODE = $$(strings $$ALIASES/serial0) ]; then \
             echo 0; \
-        elif [ $$TTYNODE = $$(strings $$ALIASES/serial1) ]; then \
+        elif [ -e $$ALIASES/serial1 ] && [ $$TTYNODE = $$(strings $$ALIASES/serial1) ]; then \
             echo 1; \
-        elif [ $$TTYNODE = $$(strings $$ALIASES/uart0 | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
+        elif [ -e $$ALIASES/uart0 ] && [ $$TTYNODE = $$(strings $$ALIASES/uart0 | sed 's/.*rp1\\/serial@/\\/soc\\/serial@1f000/' ) ]; then \
             echo 0; \
-        elif [ $$TTYNODE = $$(strings $$ALIASES/uart10 | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
+        elif [ -e $$ALIASES/uart10 ] && [ $$TTYNODE = $$(strings $$ALIASES/uart10 | sed 's/.*\\//\\/soc\\//' | sed 's/serial@/serial@10/' ) ]; then \
             echo 0; \
         else \
             exit 1; \


### PR DESCRIPTION
#95 and #97 fixed the `/dev/serial0` symlinks on kernel 6.12 for Pi 4 (bcm2711) and Pi 5 (bcm2712), but https://github.com/raspberrypi/bookworm-feedback/issues/401#issuecomment-2802282606 reported that it still wasn't working correctly for Pi 3+ (bcm2837). Further testing showed that it wasn't working for Pi Zero W (bcm2835) or Pi 2 (bcm2836) either.

After _much_ fiddling, tinkering and testing, I've now got a solution that (AFAICT!) correctly works for **all** models of Raspberry Pi. ~~And while I was at it I also managed to get the `/dev/serial1` -> bluetooth-UART (when `dtparam=krnbt=off` is set in `config.txt`) symlink working for Pi 5 too.~~

The first commit in here ("More serial0 fixes...") is the only one that's essential - I'm happy to split the later commits out into a separate PR if you'd prefer that.

ping @timg236 and @pelwell and @XECDesign 