### PR TITLE
firstboot: add check for p5

### DIFF
--- a/initramfs-tools/scripts/local-premount/firstboot
+++ b/initramfs-tools/scripts/local-premount/firstboot
@@ -49,10 +49,10 @@ do_resize () {
 . /scripts/functions
 . /scripts/local
 
-log_begin_msg "Resizing root filesystem...\n\nDepending on storage size and speed, this may take a while."
 
 get_variables
-if ! [ -b "${ROOT_DEV}5" ]; then
+if ! [ -b "${ROOT_DEV}5" ] && ! [ -b "${ROOT_DEV}p5" ] ; then
+  log_begin_msg "Resizing root filesystem...\n\nDepending on storage size and speed, this may take a while."
   do_resize
 else
   log_warning_msg "Resize skipped due to unexpected partition table"


### PR DESCRIPTION
local-premount/firstboot:
Checked for ${ROOT_DEV}p5 as well as ${ROOT_DEV}5" to cater for nvme & mmcblk0 drives. Moved log message.
