### PR TITLE
Fix get_fw_loc failing on non-arm platforms

### DIFF
--- a/usr/lib/raspberrypi-sys-mods/get_fw_loc
+++ b/usr/lib/raspberrypi-sys-mods/get_fw_loc
@@ -7,13 +7,13 @@ fi
 if [ -z "$FWLOC" ]; then
   if ! dpkg --print-architecture | grep -q '^arm'; then
     FWLOC=/boot
-    break
+  else
+    for FWLOC in /boot/firmware /boot NOT_FOUND; do
+      if ( findmnt --fstab "$FWLOC" || findmnt "$FWLOC" ) > /dev/null; then
+        break
+      fi
+    done
   fi
-  for FWLOC in /boot/firmware /boot NOT_FOUND; do
-    if ( findmnt --fstab "$FWLOC" || findmnt "$FWLOC" ) > /dev/null; then
-      break
-    fi
-  done
   if [ "$FWLOC" = "NOT_FOUND" ]; then
     echo "WARNING: Firmware partition not found, searching for config.txt.."  >$2
     for FWLOC in /boot/firmware /boot NOT_FOUND; do


### PR DESCRIPTION
Raised issue #100 for this.

In get_fw_loc there was an invalid break statement which was causing the whole script to fail on non-arm platforms. Removed the break and replaced it with an if-else.